### PR TITLE
Using node v0.12.0 built in execSync

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ var Template    = Mincer.Template;
 var prop        = require('mincer/lib/mincer/common').prop;
 var path        = require('path');
 var fs          = require('fs');
-var sh          = require('execSync');
+var sh          = require('child_process');
 var temp        = require('temp');
 var includeDirs = [];
 
@@ -62,7 +62,7 @@ RubySassEngine.prototype.evaluate = function (context, locals) {
 
   fs.writeFileSync(scssInputPath, this.data);
 
-  var exec = sh.exec(cmd.join(' '));
+  var exec = sh.execSync(cmd.join(' '));
 
   if (!fs.existsSync(dependencyPath)) {
     throw new Error('Could not load dependent files from Sass: file does not exist.\n' + exec.stdout);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "Ruby Sass engine for Mincer",
   "main": "index.js",
   "dependencies": {
-    "execSync": "~1.0.1-pre",
     "mincer": "~1.0.0",
     "temp": "^0.8.1"
   },


### PR DESCRIPTION
The execSync previously used was a library which has been
deprectated. The node team has put this functionality into Node
starting with v0.12.0.

This change will allow us to not require execSync which is now
breaking when doing installs.