### PR TITLE
execSync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ results
 
 npm-debug.log
 node_modules
+
+.sass-cache/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: node_js
+node_js:
+  - "0.10"
+before_script:
+  - gem install bundler
+  - bundle
+script:
+  - npm test

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'sass', '~> 3.3.4'
+gem 'sass', '~> 3.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,10 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    sass (3.3.4)
+    sass (3.4.13)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  sass (~> 3.3.4)
+  sass (~> 3.4)

--- a/bin/sass
+++ b/bin/sass
@@ -30,7 +30,15 @@ if index = ARGV.index(OPTION_NAME)
   dependency_path = ARGV.delete_at(index)
 end
 
-opts = Sass::Exec::Sass.new(ARGV)
+case Sass::VERSION
+when /^3\.4/
+  opts = Sass::Exec::SassScss.new(ARGV, :sass)
+when /^3\./
+  opts = Sass::Exec::Sass.new(ARGV)
+else
+  raise "mincer-ruby-sass requires Sass 3.1+"
+end
+
 begin
   opts.parse!
 rescue SystemExit

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Ruby Sass engine for Mincer",
   "main": "index.js",
   "dependencies": {
-    "execSync": "~1.0.1-pre",
     "mincer": "~1.0.0",
+    "sync-exec": "^0.5.0",
     "temp": "^0.8.1"
   },
   "scripts": {


### PR DESCRIPTION
Switch to using `sync-exec` which uses Node 0.12's native `execSync` if available, and falls back to a JS-only implementation otherwise - no native extensions required.