### PR TITLE
Add sourcemap support

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,8 +107,8 @@ RubySassEngine.prototype.evaluate = function (context, locals) {
     }
   }
 
-  if (exec.status) {
-    throw new Error('Error compiling Sass: ' + exec + "\n" + exec.stdout);
+  if (exec.status || !fs.existsSync(cssOutputPath)) {
+    throw new Error('Error compiling Sass: ' + exec.stderr + "\n" + exec.stdout);
   } else {
     return this.data = fs.readFileSync(cssOutputPath, { encoding: 'utf8' });
   }


### PR DESCRIPTION
- Add Sass sourcemap support
- Adds a `showRawOutput` predicate method to handle rendering of raw
  Sass files. If imported files use mixins or variables defined
  elsewhere, they will likely fail Sass compilation when accessed
  directly. This can allow you to selectively show the Raw output on
  certain files. I cannot think of any other way to show the raw Sass
  from an imported file if it fails to compile in isolation.
